### PR TITLE
Removed index key from list iterator

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12793,8 +12793,7 @@
     "nanoid": {
       "version": "3.1.23",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.23.tgz",
-      "integrity": "sha512-FiB0kzdP0FFVGDKlRLEQ1BgDzU87dy5NnzjeW9YZNt+/c3+q82EQDUwniSAUxp/F0gFNI1ZhKU1FqYsMuqZVnw==",
-      "dev": true
+      "integrity": "sha512-FiB0kzdP0FFVGDKlRLEQ1BgDzU87dy5NnzjeW9YZNt+/c3+q82EQDUwniSAUxp/F0gFNI1ZhKU1FqYsMuqZVnw=="
     },
     "nanomatch": {
       "version": "1.2.13",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "express-static-gzip": "^2.0.7",
     "handlebars": "^4.7.7",
     "helmet": "^3.23.3",
+    "nanoid": "^3.1.23",
     "node-fetch": "^2.6.1",
     "normalize.css": "^8.0.0",
     "pretty-error": "^2.1.1",

--- a/readme.md
+++ b/readme.md
@@ -31,6 +31,7 @@ If you want to view the solution, checkout into the `solution` branch.
 
 ```
 git checkout solution
+npm install
 npm run start
 ```
 

--- a/src/js/components/List/index.jsx
+++ b/src/js/components/List/index.jsx
@@ -33,10 +33,7 @@ const List = () => {
     <section>
       <ul id="list" className="mx-auto max-w-sm p-4 space-y-4">
         {list &&
-          list.map((n) => (
-            // eslint-disable-next-line react/no-array-index-key
-            <ListItem key={n.id} img={n.img} text={n.text} />
-          ))}
+          list.map((n) => <ListItem key={n.id} img={n.img} text={n.text} />)}
       </ul>
     </section>
   );

--- a/src/js/components/List/index.jsx
+++ b/src/js/components/List/index.jsx
@@ -1,3 +1,4 @@
+import { nanoid } from "nanoid";
 import React, { useEffect, useState } from "react";
 
 import ListItem from "../ListItem";
@@ -9,7 +10,7 @@ const LOREM_IPSUM =
 const List = () => {
   const [list, setList] = useState([
     {
-      id: 0,
+      id: nanoid(),
       img: 0,
       text: LOREM_IPSUM,
     },
@@ -20,7 +21,7 @@ const List = () => {
     setTimeout(() => {
       setList([
         {
-          id: Math.random() * 100000000,
+          id: nanoid(),
           img: Math.ceil(Math.random() * 8),
           text: LOREM_IPSUM.slice(Math.ceil(Math.random() * 100)),
         },

--- a/src/js/components/List/index.jsx
+++ b/src/js/components/List/index.jsx
@@ -9,6 +9,7 @@ const LOREM_IPSUM =
 const List = () => {
   const [list, setList] = useState([
     {
+      id: 0,
       img: 0,
       text: LOREM_IPSUM,
     },
@@ -19,6 +20,7 @@ const List = () => {
     setTimeout(() => {
       setList([
         {
+          id: Math.random() * 100000000,
           img: Math.ceil(Math.random() * 8),
           text: LOREM_IPSUM.slice(Math.ceil(Math.random() * 100)),
         },
@@ -31,9 +33,9 @@ const List = () => {
     <section>
       <ul id="list" className="mx-auto max-w-sm p-4 space-y-4">
         {list &&
-          list.map((n, index) => (
+          list.map((n) => (
             // eslint-disable-next-line react/no-array-index-key
-            <ListItem key={index} img={n.img} text={n.text} />
+            <ListItem key={n.id} img={n.img} text={n.text} />
           ))}
       </ul>
     </section>


### PR DESCRIPTION
This PR illustrates the solution to the layout instability issue caused when adding items to a React list.

The issue is caused by using an `index` as the `key` prop on a child item in a List. This also throws a linting error which was disabled on the `main` branch using

```
// eslint-disable-next-line react/no-array-index-key
```

By using a valid key prop (for example a value coming from the API) allows the iterator to recognise which element has remained and which is new.

Internally, React uses a data structure referred to as a fiber. A fiber may be considered an abstraction for a unit of work. Whenever we render a React application, the result is a fiber tree that reflects the current state of the application, named `current`. When React handles an interaction or starts processing updates, it takes the `current` tree and processes these changes on it, resulting in a new updated tree, known as the `workInProgress`. 

By using the `index` as a `key` prop, then the value of the index on each item is changing whenever a new item is appended to the list. This causes React to get "confused" and incorrectly mix the state of the newly added item (which now has `key=0`) and the previous item (which was previously `key=0` but is now `key=1`).